### PR TITLE
revert: restore Innovation Lab text

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -45,7 +45,7 @@
           <ul class="space-y-2 text-gray-300">
             <li><a href="#" class="hover:text-white">Dedicated desks & hot desks</a></li>
             <li><a href="#" class="hover:text-white">Workspace</a></li>
-            <li><a href="#" class="hover:text-white">High-speed internet & reliable Wi-Fi</a></li>
+            <li><a href="#" class="hover:text-white">Innovation Lab</a></li>
             <li><a href="#" class="hover:text-white">Training</a></li>
           </ul>
         </div>

--- a/src/index.md
+++ b/src/index.md
@@ -50,7 +50,7 @@ description: "Phoenix Technology Center - Modern workspace and technology soluti
       </div>
       
       <div class="bg-white p-6 rounded-lg shadow-md border border-gray-200">
-        <h3 class="text-xl font-semibold text-gray-900 mb-3">High-speed internet & reliable Wi-Fi</h3>
+        <h3 class="text-xl font-semibold text-gray-900 mb-3">Innovation Lab</h3>
         <p class="text-gray-600">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
       </div>
       


### PR DESCRIPTION
Reverts the previous changes back to "Innovation Lab" from "High-speed internet & reliable Wi-Fi"

Changes:
- Restored homepage service card heading to "Innovation Lab"
- Restored footer navigation menu to "Innovation Lab"

Fixes #19

Generated with [Claude Code](https://claude.ai/code)