### PR TITLE
feat: add pale phoenix background pattern

### DIFF
--- a/src/_includes/css/main.css
+++ b/src/_includes/css/main.css
@@ -1,3 +1,37 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Phoenix-inspired background */
+@layer base {
+  body {
+    position: relative;
+  }
+  
+  body::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: -1;
+    opacity: 0.03;
+    background: 
+      radial-gradient(ellipse 800px 600px at 50% 40%, 
+        rgba(255, 69, 0, 0.2) 0%,
+        rgba(255, 165, 0, 0.1) 30%,
+        transparent 70%),
+      radial-gradient(ellipse 400px 300px at 30% 60%, 
+        rgba(220, 38, 38, 0.15) 0%,
+        transparent 60%),
+      radial-gradient(ellipse 400px 300px at 70% 60%, 
+        rgba(220, 38, 38, 0.15) 0%,
+        transparent 60%),
+      linear-gradient(45deg, 
+        rgba(255, 69, 0, 0.02) 0%,
+        transparent 50%,
+        rgba(255, 165, 0, 0.02) 100%);
+  }
+}


### PR DESCRIPTION
Adds a subtle phoenix-inspired background pattern to the website using CSS gradients.

✨ **Features:**
- Ultra-low opacity (3%) for subtle effect
- Phoenix wing pattern using radial gradients
- Brand-consistent red-orange color palette
- Fixed positioning that doesn't scroll
- Zero interference with content readability

Fixes #37

Generated with [Claude Code](https://claude.ai/code)