### PR TITLE
fix: darken blue background on "Dedicated desks & hot desks" section

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -39,7 +39,7 @@ description: "Phoenix Technology Center - Modern workspace and technology soluti
     </div>
 
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-8">
-      <div class="bg-blue-50 p-6 rounded-lg shadow-md border border-gray-200">
+      <div class="bg-blue-100 p-6 rounded-lg shadow-md border border-gray-200">
         <h3 class="text-xl font-semibold text-gray-900 mb-3 text-center">Dedicated desks & hot desks</h3>
         <p class="text-gray-600">A mix of reserved and flexible seating for different work styles.</p>
       </div>


### PR DESCRIPTION
Darkened the blue background on the "Dedicated desks & hot desks" section from bg-blue-50 to bg-blue-100 to make it more visible and visually appealing.

Fixes #59

Generated with [Claude Code](https://claude.ai/code)