### PR TITLE
feat: change Phoenix Technology Center text color from blue to orange

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -15,7 +15,7 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center">
-          <a href="/" class="text-xl font-bold text-blue-600" style="color: #2563eb;">Phoenix Tech Center</a>
+          <a href="/" class="text-xl font-bold text-orange-600" style="color: #ea580c;">Phoenix Tech Center</a>
         </div>
         <div class="hidden md:flex md:items-center md:space-x-8">
           <a href="/" class="text-gray-600 hover:text-gray-900">Home</a>

--- a/src/index.njk
+++ b/src/index.njk
@@ -8,7 +8,7 @@ description: "Phoenix Technology Center - Modern workspace and technology soluti
 <section class="bg-gray-50 py-20">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center">
-      <h1 class="text-4xl md:text-6xl font-bold text-blue-600 mb-6" style="color: #2563eb;">
+      <h1 class="text-4xl md:text-6xl font-bold text-orange-600 mb-6" style="color: #ea580c;">
         Phoenix Technology Center
       </h1>
       <p class="text-xl text-gray-600 mb-8 max-w-3xl mx-auto">


### PR DESCRIPTION
Updated main title and navigation logo to use orange-600 color instead of blue-600 for better branding alignment.

Resolves #83

Generated with [Claude Code](https://claude.ai/code)