### PR TITLE
Remove italic formatting from 'Networking Events' text

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -95,7 +95,7 @@ description: "Phoenix Technology Center - Modern workspace and technology soluti
         Monthly Events & Socials
       </h2>
       <p class="text-lg text-gray-600 max-w-2xl mx-auto">
-        <em>Networking Events</em>, Game Nights, Happy Hours, and Learning Sessions to Build Community
+        Networking Events, Game Nights, Happy Hours, and Learning Sessions to Build Community
       </p>
     </div>
 


### PR DESCRIPTION
Remove <em> tags around 'Networking Events' in Monthly Events & Socials section to make the entire phrase appear in regular font instead of italics.

Fixes #139

Generated with [Claude Code](https://claude.ai/code)