### PR TITLE
Remove 24/7 Access section from About Us page

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -156,13 +156,6 @@ description: "Phoenix Technology Center - Modern workspace and technology soluti
         <p class="text-gray-600">Your peace of mind matters. Our facility is equipped with secure access controls, monitored entry points, and a protected network to keep your data and belongings safe. Whether you're working on sensitive projects or just want to store your laptop with confidence, we've got you covered.</p>
       </div>
 
-      <div class="text-center">
-        <div class="w-16 h-16 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-4">
-          <div class="w-8 h-8 bg-purple-600 rounded"></div>
-        </div>
-        <h3 class="text-xl font-semibold text-gray-900 mb-3">24/7 Access</h3>
-        <p class="text-gray-600">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore.</p>
-      </div>
 
       <div class="text-center">
         <div class="w-16 h-16 bg-orange-100 rounded-lg flex items-center justify-center mx-auto mb-4">


### PR DESCRIPTION
Removes the "24/7 Access" section from the About Us page as requested in issue #147.

Changes:
- Removed the entire "24/7 Access" div block from src/index.njk
- About Us section now displays 3 columns instead of 4

Fixes #147

Generated with [Claude Code](https://claude.ai/code)