### PR TITLE
Remove 'Call Us' section from Contact page

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -187,10 +187,6 @@ description: "Phoenix Technology Center - Modern workspace and technology soluti
           <p class="text-gray-600">1234 Innovation Drive<br>Phoenix, AZ 85001<br>United States</p>
         </div>
 
-        <div>
-          <h3 class="text-xl font-semibold text-gray-900 mb-2 text-center">Call Us</h3>
-          <p class="text-gray-600">+1 (555) 123-4567<br>Monday - Friday: 9AM - 6PM</p>
-        </div>
 
         <div>
           <h3 class="text-xl font-semibold text-gray-900 mb-2 text-center">Email Us</h3>


### PR DESCRIPTION
Removes the "Call Us" section from the Contact page as requested in issue #153.

The section contained a phone number and business hours that was located in the Contact section of the homepage.

Generated with [Claude Code](https://claude.ai/code)