### PR TITLE
Remove Email Us section from Contact page

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -188,10 +188,6 @@ description: "Phoenix Technology Center - Modern workspace and technology soluti
         </div>
 
 
-        <div>
-          <h3 class="text-xl font-semibold text-gray-900 mb-2 text-center">Email Us</h3>
-          <p class="text-gray-600">hello@phoenixtech.center<br>We'll get back to you within 24 hours</p>
-        </div>
       </div>
 
     </div>


### PR DESCRIPTION
This PR removes the "Email Us" section from the Contact page as requested in issue #155.

## Changes
- Removed the Email Us div block from src/index.njk
- Maintained the existing Contact section structure
- Tested build process to ensure no errors

Fixes #155

Generated with [Claude Code](https://claude.ai/code)