### PR TITLE
fix: update site name to Phoenix Technology Center

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -15,7 +15,7 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between h-16">
         <div class="flex items-center">
-          <a href="/" class="text-xl font-bold text-orange-600" style="color: #ea580c;">Phoenix Tech Center</a>
+          <a href="/" class="text-xl font-bold text-orange-600" style="color: #ea580c;">Phoenix Technology Center</a>
         </div>
         <div class="hidden md:flex md:items-center md:space-x-8">
           <a href="/" class="text-gray-600 hover:text-gray-900">Home</a>
@@ -37,7 +37,7 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
         <div>
-          <h3 class="text-lg font-semibold mb-4 text-center">Phoenix Tech Center</h3>
+          <h3 class="text-lg font-semibold mb-4 text-center">Phoenix Technology Center</h3>
           <p class="text-gray-300">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.</p>
         </div>
         <div>


### PR DESCRIPTION
Updates the site name from "Phoenix Tech Center" to "Phoenix Technology Center" in both the navigation header and footer to match the full official name.

Closes #161

Generated with [Claude Code](https://claude.ai/code)