### PR TITLE
Remove Phoenix Technology Center and Services sections from footer

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -35,22 +35,9 @@
   <!-- Footer -->
   <footer class="bg-gray-800 text-white">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-12">
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-        <div>
-          <h3 class="text-lg font-semibold mb-4 text-center">Phoenix Technology Center</h3>
-          <p class="text-gray-300">A modern coworking space designed for your needs.</p>
-        </div>
-        <div>
-          <h3 class="text-lg font-semibold mb-4 text-center">Services</h3>
-          <ul class="space-y-2 text-gray-300">
-            <li><a href="#" class="hover:text-white">Choose Your Perfect Work Setup</a></li>
-            <li><a href="#" class="hover:text-white">Workspace</a></li>
-            <li><a href="#" class="hover:text-white">Power Up with Ease</a></li>
-            <li><a href="#" class="hover:text-white">Training</a></li>
-          </ul>
-        </div>
-        <div>
-          <h3 class="text-lg font-semibold mb-4 text-center">Contact</h3>
+      <div class="flex justify-center">
+        <div class="text-center">
+          <h3 class="text-lg font-semibold mb-4">Contact</h3>
           <div class="space-y-2 text-gray-300">
             <p>hello@phoenixtech.center</p>
             <p>+1 (555) 123-4567</p>


### PR DESCRIPTION
Remove "Phoenix Technology Center" and "Services" sections from footer, keeping only "Contact" section.

Changes:
- Modified `/src/_includes/layouts/base.njk` to remove first two footer columns
- Changed from 3-column grid to centered single column layout
- Contact section now centered using flexbox

Closes #167

Generated with [Claude Code](https://claude.ai/code)